### PR TITLE
fix: TSX paste indentation (one-line elements + charwise trailing blank)

### DIFF
--- a/lua/smart-paste/paste.lua
+++ b/lua/smart-paste/paste.lua
@@ -63,13 +63,14 @@ end
 
 --- Heuristic: line opens an HTML/Vue-like tag block.
 --- Supports single-line tag openers and multiline opener tails (`>` line).
+--- A complete element closed on the same line (e.g. JSX `<li>x</li>`) is not an opener.
 --- @param line string
 --- @return boolean
 local function looks_like_tag_opener(line)
   if line:match('^%s*>%s*$') then
     return true
   end
-  if line:match('^%s*<[%w:_-]') and line:match('>%s*$') and not line:match('/>%s*$') and not line:match('^%s*</') then
+  if line:match('^%s*<[%w:_-]') and line:match('>%s*$') and not line:match('/>%s*$') and not line:match('</') then
     return true
   end
   return false

--- a/tests/verify_task2_e2e.lua
+++ b/tests/verify_task2_e2e.lua
@@ -722,6 +722,47 @@ if lines32[3] ~= '      foo := 42' then
 end
 print('PASS: [p above closer with blank inner line indents inside tag block')
 
+-- Test 33: (issue #11) p after a complete one-line JSX element that sits just
+-- above a closing tag must NOT over-indent. A self-closed element like
+-- `<li>one</li>` is not a block opener, so the sibling lands at the same level.
+set_buf_lines({
+  'function List() {',
+  '    return (',
+  '        <ul>',
+  '            <li>one</li>',
+  '        </ul>',
+  '    );',
+  '}',
+})
+vim.fn.setreg('g', { '<li>two</li>' }, 'V')
+vim.api.nvim_win_set_cursor(0, { 4, 0 })
+paste._test_set_state('g', 1, 'p')
+paste.do_paste('line')
+local lines33 = get_buf_lines()
+if lines33[5] ~= '            <li>two</li>' then
+  fail_with_buffer('p after one-line JSX element should keep sibling at same indent (issue #11)')
+end
+print('PASS: p after one-line JSX element keeps sibling indent (issue #11)')
+
+-- Test 34: genuine single-line tag opener still indents its child one level in.
+set_buf_lines({
+  'function App() {',
+  '    return (',
+  '        <div>',
+  '        </div>',
+  '    );',
+  '}',
+})
+vim.fn.setreg('h', { '<span>hi</span>' }, 'V')
+vim.api.nvim_win_set_cursor(0, { 3, 0 })
+paste._test_set_state('h', 1, 'p')
+paste.do_paste('line')
+local lines34 = get_buf_lines()
+if lines34[4] ~= '            <span>hi</span>' then
+  fail_with_buffer('p on real <div> opener should indent child one level inside block')
+end
+print('PASS: p on real tag opener still indents child inside block')
+
 print('')
 print('ALL END-TO-END INTEGRATION TESTS PASSED')
 vim.cmd('qa!')


### PR DESCRIPTION
Two related TSX/JSX paste indentation fixes found while investigating #11.

### 1. Complete one-line JSX elements no longer treated as block openers

The tag-opener heuristic treated any line starting with `<tag` and ending with `>` as a block opener (which adds an indent level to pasted content). Complete one-line elements match that shape too:

- `<li>one</li>`
- `<Foo prop={x}>child</Foo>`
- `<span>{name}</span>`

So pasting a sibling after one of these — especially the last child, right above a closing tag — landed it one level too deep:

```tsx
<ul>
    <li>one</li>
        <li>two</li>   // before: over-indented
</ul>
```

Fix: a line that closes a tag on itself (contains `</`) is not an opener. Genuine multi-line openers (`<div>`, `<div className="x">`, a wrapped tag's `>` tail) still indent their children.

### 2. `]p` / `[p` strip the trailing blank from line-boundary charwise selections

A charwise selection ending at a line boundary (e.g. `v$`) captures the trailing newline, so the register becomes `{ "<li>one</li>", "" }`. Converting that to a linewise paste left a stray blank line below the pasted text. Trailing empty lines are now dropped (keeping at least one) before indenting, so element-style selections paste cleanly however they were selected.

### Tests

- `verify_task2_e2e.lua`: pasting a sibling after a one-line JSX element keeps it at the same indent; a genuine single-line `<div>` opener still indents its child.
- `charwise_paste_spec.lua`: `]p` on a `v$`-style charwise register doesn't leave a stray blank line.

All existing specs and integration checks pass.

Note: this does **not** close #11 — that report is about using `p` on a charwise selection, which is expected (use `]p` / `[p`). These are separate bugs surfaced along the way.
