### PR TITLE
fix: preserve relative indent when pasting multi-line charwise blocks (]p/[p)

### DIFF
--- a/lua/smart-paste/indent.lua
+++ b/lua/smart-paste/indent.lua
@@ -44,6 +44,43 @@ function M.get_source_indent(lines)
   return 0
 end
 
+--- Reconstruct the first line's indentation for a charwise "paste as new line".
+--- A charwise selection drops the first line's leading whitespace while inner
+--- lines keep their absolute indent, so a single uniform shift over-indents the
+--- inner lines by the block's original base. When the block dedents back below
+--- its first inner line (e.g. a closing tag or brace), the first line is an
+--- opener whose base equals the block's minimum inner indent; re-pad it to that
+--- base so the uniform shift preserves the block's relative structure. Blocks
+--- that never dedent (e.g. `if x:` + body) keep the first line at column 0.
+--- @param lines string[] Lines with the first line already left-stripped
+--- @return string[] rebased New table; first line padded to the detected base
+--- @return integer base Visual-column base indent to use as the source indent
+function M.rebase_charwise_block(lines)
+  local result = vim.deepcopy(lines)
+  if #result == 0 then
+    return result, 0
+  end
+
+  local first_inner, min_inner
+  for i = 2, #result do
+    if not is_blank(result[i]) then
+      local vcols = leading_vcols(result[i])
+      if first_inner == nil then
+        first_inner = vcols
+      end
+      if min_inner == nil or vcols < min_inner then
+        min_inner = vcols
+      end
+    end
+  end
+
+  if first_inner ~= nil and min_inner < first_inner then
+    result[1] = string.rep(' ', min_inner) .. result[1]
+    return result, min_inner
+  end
+  return result, 0
+end
+
 --- Heuristic indent fallback: scan upward to nearest non-empty line and
 --- measure its leading whitespace in visual columns.
 --- @param bufnr integer Buffer handle

--- a/lua/smart-paste/paste.lua
+++ b/lua/smart-paste/paste.lua
@@ -257,12 +257,15 @@ function M.do_paste(_motion_type)
     if charwise_newline and is_charwise then
       local lines = strip_trailing_blank_lines(reginfo.regcontents)
       local stripped = strip_leading_whitespace(lines)
-      local source_indent = indent.get_source_indent(stripped)
+      -- Charwise selections drop the first line's indent but keep the inner
+      -- lines' absolute indent; rebase the first line so the block's relative
+      -- structure survives the shift to the target indent.
+      local rebased, source_indent = indent.rebase_charwise_block(stripped)
       local bufnr = vim.api.nvim_get_current_buf()
       local row = vim.api.nvim_win_get_cursor(0)[1] - 1 -- 0-indexed
       local target_indent = resolve_linewise_target_indent(bufnr, row, after)
       local delta = target_indent - source_indent
-      local adjusted = indent.apply_delta(stripped, delta, bufnr)
+      local adjusted = indent.apply_delta(rebased, delta, bufnr)
       local final_lines = repeat_lines(adjusted, count)
       vim.api.nvim_put(final_lines, 'l', after, follow)
       return

--- a/tests/charwise_paste_spec.lua
+++ b/tests/charwise_paste_spec.lua
@@ -244,6 +244,42 @@ group('charwise_paste', function()
     delete_buf(bufnr)
   end)
 
+  case(']p preserves relative indent of a multi-line block (charwise mid-line select)', function()
+    -- A `^v...y` selection of an indented block drops line 1's whitespace but
+    -- keeps the inner lines' absolute indent. The pasted sibling must match the
+    -- original block's structure, not be over-indented by its base indent.
+    local bufnr = make_buf({
+      '<Wrapper>',
+      '    <Group>',
+      '        <Item />',
+      '    </Group>',
+      '</Wrapper>',
+    })
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('l', { '<Group>', '        <Item />', '    </Group>' }, 'v')
+    vim.api.nvim_win_set_cursor(0, { 4, 0 })
+    paste._test_set_state({
+      register = 'l',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), {
+      '<Wrapper>',
+      '    <Group>',
+      '        <Item />',
+      '    </Group>',
+      '    <Group>',
+      '        <Item />',
+      '    </Group>',
+      '</Wrapper>',
+    })
+    delete_buf(bufnr)
+  end)
+
   case(']p with empty charwise register does not crash', function()
     local bufnr = make_buf({ 'def foo():', '    x = 1', '' })
     vim.api.nvim_set_current_buf(bufnr)

--- a/tests/indent_spec.lua
+++ b/tests/indent_spec.lua
@@ -366,4 +366,29 @@ describe('indent', function()
       delete_buf(bufnr)
     end)
   end)
+
+  describe('rebase_charwise_block', function()
+    it('rebases first line to block base when the block dedents (closing tag)', function()
+      -- Mimics a `^v...y` charwise selection of an indented block: line 1 lost
+      -- its leading whitespace, inner lines kept their absolute indent.
+      local lines = { '<Group>', '        <Item />', '    </Group>' }
+      local rebased, base = indent.rebase_charwise_block(lines)
+      assert.are.equal(4, base)
+      assert.are.same({ '    <Group>', '        <Item />', '    </Group>' }, rebased)
+    end)
+
+    it('keeps first line at column 0 when the block never dedents', function()
+      local lines = { 'if True:', '    pass' }
+      local rebased, base = indent.rebase_charwise_block(lines)
+      assert.are.equal(0, base)
+      assert.are.same({ 'if True:', '    pass' }, rebased)
+    end)
+
+    it('returns base 0 and leaves single-line content untouched', function()
+      local lines = { '<li>x</li>' }
+      local rebased, base = indent.rebase_charwise_block(lines)
+      assert.are.equal(0, base)
+      assert.are.same({ '<li>x</li>' }, rebased)
+    end)
+  end)
 end)


### PR DESCRIPTION
Fixes #11.

## The real bug

```tsx
<DateField.Group>
  <Button>Select Month</Button>
</DateField.Group>
<DateField.Group>
      <Button>Select Month</Button>   // before: over-indented
    </DateField.Group>                // before: over-indented
```

## Cause

A charwise selection (e.g. `^v...y`) drops the **first** line's leading whitespace, but the inner lines keep their **absolute** indent. The `]p`/`[p` path then shifted every line by a single delta computed from the first line — so the inner lines got the block's original base indent counted twice. (Vim's native `]p` has the same flaw; smart-paste should do better.)

"Copying the whole line" worked because that's a *linewise* yank, which keeps the first line's indent and goes through a different path.

## Fix

When a block **dedents back below its first inner line** (a closing tag/brace — the normal shape of a JSX element, `{}`, `()` block), the first line is an opener whose true base equals the block's minimum inner indent. Reconstruct it to that base before shifting, so the block's relative structure is preserved.

Blocks that never dedent (e.g. `if x:` + body, where the first line genuinely sits at column 0) keep the first line at 0 — existing behavior is unchanged.

After:

```tsx
<DateField.Group>
  <Button>Select Month</Button>
</DateField.Group>
<DateField.Group>
  <Button>Select Month</Button>   // matches the original
</DateField.Group>
```

## Tests

- `indent_spec.lua`: unit tests for the new `rebase_charwise_block` (dedenting block, non-dedenting block, single line).
- `charwise_paste_spec.lua`: `]p` of a multi-line block from a mid-line charwise selection now matches the original structure instead of over-indenting.

All existing specs and integration checks pass.
