### PR TITLE
fix: ignore trailing inline comments in scope detection heuristics

### DIFF
--- a/lua/smart-paste/heuristics.lua
+++ b/lua/smart-paste/heuristics.lua
@@ -1,0 +1,109 @@
+--- @class SmartPaste.Heuristics
+local M = {}
+
+--- Escape Lua pattern magic characters in a plain string.
+--- Needed because comment leaders like `--` contain pattern magic (`-`).
+--- @param text string
+--- @return string escaped
+local function escape_pattern(text)
+  return (text:gsub('[%^%$%(%)%%%.%[%]%*%+%-%?]', '%%%0'))
+end
+
+--- Strip a trailing inline comment from a line using the buffer's
+--- `commentstring` (e.g. `# %s` for python, `-- %s` for lua).
+--- Only a comment leader preceded by whitespace is stripped, which keeps
+--- false positives low (a leader character mid-word is left alone).
+--- @param line string
+--- @param bufnr integer
+--- @return string line
+local function strip_trailing_comment(line, bufnr)
+  local commentstring = vim.bo[bufnr].commentstring or ''
+  local leader = vim.trim(commentstring:match('^(.-)%%s') or '')
+  if leader == '' then
+    return line
+  end
+  return (line:gsub('%s+' .. escape_pattern(leader) .. '.*$', ''))
+end
+
+--- Heuristic: line opens an HTML/Vue-like tag block.
+--- Supports single-line tag openers and multiline opener tails (`>` line).
+--- A complete element closed on the same line (e.g. JSX `<li>x</li>`) is not an opener.
+--- @param line string
+--- @return boolean
+local function looks_like_tag_opener(line)
+  if line:match('^%s*>%s*$') then
+    return true
+  end
+  if line:match('^%s*<[%w:_-]') and line:match('>%s*$') and not line:match('/>%s*$') and not line:match('</') then
+    return true
+  end
+  return false
+end
+
+--- Heuristic: line closes an HTML/Vue-like tag block.
+--- @param line string
+--- @return boolean
+local function looks_like_tag_closer(line)
+  return line:match('^%s*</[%w:_-][^>]*>%s*$') ~= nil
+end
+
+local SCOPE_OPENER_KEYWORDS = { 'then', 'do', 'else', 'elseif', 'repeat', 'function' }
+local SCOPE_CLOSER_KEYWORDS = { 'end', 'elif', 'else', 'elseif', 'catch', 'finally' }
+
+--- Heuristic: line ends with an opener token for block-like constructs.
+--- @param line string
+--- @return boolean
+local function looks_like_scope_opener(line)
+  if line:match('[%{%[%(:]%s*$') then
+    return true
+  end
+  if looks_like_tag_opener(line) then
+    return true
+  end
+  -- Lua patterns have no alternation; test each keyword separately.
+  for _, keyword in ipairs(SCOPE_OPENER_KEYWORDS) do
+    if line:match('%f[%a]' .. keyword .. '%s*$') then
+      return true
+    end
+  end
+  return false
+end
+
+--- Heuristic: line begins with a closing token for block-like constructs.
+--- @param line string
+--- @return boolean
+local function looks_like_scope_closer(line)
+  if line:match('^%s*[%}%]%)]') then
+    return true
+  end
+  if looks_like_tag_closer(line) then
+    return true
+  end
+  -- Lua patterns have no alternation; test each keyword separately.
+  for _, keyword in ipairs(SCOPE_CLOSER_KEYWORDS) do
+    if line:match('^%s*' .. keyword .. '%f[%A]') then
+      return true
+    end
+  end
+  return false
+end
+
+--- Whether a line opens a block-like scope, ignoring any trailing inline
+--- comment (e.g. `if foo < bar: # note` still reads as an opener).
+--- @param line string
+--- @param bufnr? integer Buffer whose `commentstring` applies (defaults to current buffer)
+--- @return boolean
+function M.is_scope_opener(line, bufnr)
+  return looks_like_scope_opener(strip_trailing_comment(line, bufnr or 0))
+end
+
+--- Whether a line closes a block-like scope, ignoring any trailing inline
+--- comment (e.g. `end -- note` still reads as a closer).
+--- @param line string
+--- @param bufnr? integer Buffer whose `commentstring` applies (defaults to current buffer)
+--- @return boolean
+function M.is_scope_closer(line, bufnr)
+  return looks_like_scope_closer(strip_trailing_comment(line, bufnr or 0))
+end
+
+return M

--- a/lua/smart-paste/paste.lua
+++ b/lua/smart-paste/paste.lua
@@ -1,6 +1,7 @@
 --- @class SmartPaste.Paste
 local M = {}
 local indent = require('smart-paste.indent')
+local heuristics = require('smart-paste.heuristics')
 
 -- Module-level state: captured BEFORE g@l fires (v:register and v:count1 reset after)
 local state = {}
@@ -75,69 +76,6 @@ local function get_shiftwidth(bufnr)
   return sw
 end
 
---- Heuristic: line opens an HTML/Vue-like tag block.
---- Supports single-line tag openers and multiline opener tails (`>` line).
---- A complete element closed on the same line (e.g. JSX `<li>x</li>`) is not an opener.
---- @param line string
---- @return boolean
-local function looks_like_tag_opener(line)
-  if line:match('^%s*>%s*$') then
-    return true
-  end
-  if line:match('^%s*<[%w:_-]') and line:match('>%s*$') and not line:match('/>%s*$') and not line:match('</') then
-    return true
-  end
-  return false
-end
-
---- Heuristic: line closes an HTML/Vue-like tag block.
---- @param line string
---- @return boolean
-local function looks_like_tag_closer(line)
-  return line:match('^%s*</[%w:_-][^>]*>%s*$') ~= nil
-end
-
-local SCOPE_OPENER_KEYWORDS = { 'then', 'do', 'else', 'elseif', 'repeat', 'function' }
-local SCOPE_CLOSER_KEYWORDS = { 'end', 'elif', 'else', 'elseif', 'catch', 'finally' }
-
---- Heuristic: line ends with an opener token for block-like constructs.
---- @param line string
---- @return boolean
-local function looks_like_scope_opener(line)
-  if line:match('[%{%[%(:]%s*$') then
-    return true
-  end
-  if looks_like_tag_opener(line) then
-    return true
-  end
-  -- Lua patterns have no alternation; test each keyword separately.
-  for _, keyword in ipairs(SCOPE_OPENER_KEYWORDS) do
-    if line:match('%f[%a]' .. keyword .. '%s*$') then
-      return true
-    end
-  end
-  return false
-end
-
---- Heuristic: line begins with a closing token for block-like constructs.
---- @param line string
---- @return boolean
-local function looks_like_scope_closer(line)
-  if line:match('^%s*[%}%]%)]') then
-    return true
-  end
-  if looks_like_tag_closer(line) then
-    return true
-  end
-  -- Lua patterns have no alternation; test each keyword separately.
-  for _, keyword in ipairs(SCOPE_CLOSER_KEYWORDS) do
-    if line:match('^%s*' .. keyword .. '%f[%A]') then
-      return true
-    end
-  end
-  return false
-end
-
 --- Resolve target indent for linewise insertion at the current cursor gap.
 --- Uses neighbor context only around likely scope boundaries so ordinary
 --- top-level/adjacent indentation remains stable.
@@ -156,7 +94,7 @@ local function resolve_linewise_target_indent(bufnr, cursor_row, after)
 
   if after then
     local next_row = clamped_row + 1
-    if next_row < line_count and looks_like_scope_opener(current_line) then
+    if next_row < line_count and heuristics.is_scope_opener(current_line, bufnr) then
       local next_indent, next_line = resolve_row_context_indent(bufnr, next_row)
       if next_indent > current_indent then
         return next_indent
@@ -165,7 +103,7 @@ local function resolve_linewise_target_indent(bufnr, cursor_row, after)
         return current_indent + get_shiftwidth(bufnr)
       end
       -- Empty block case: opener followed by a closer at same indent.
-      if looks_like_scope_closer(next_line) and next_indent <= current_indent then
+      if heuristics.is_scope_closer(next_line, bufnr) and next_indent <= current_indent then
         return current_indent + get_shiftwidth(bufnr)
       end
     end
@@ -173,7 +111,7 @@ local function resolve_linewise_target_indent(bufnr, cursor_row, after)
   end
 
   local prev_row = clamped_row - 1
-  if prev_row >= 0 and looks_like_scope_closer(current_line) then
+  if prev_row >= 0 and heuristics.is_scope_closer(current_line, bufnr) then
     local prev_indent, prev_line = resolve_row_context_indent(bufnr, prev_row)
     if prev_indent > current_indent then
       return prev_indent
@@ -182,7 +120,7 @@ local function resolve_linewise_target_indent(bufnr, cursor_row, after)
       return current_indent + get_shiftwidth(bufnr)
     end
     -- Empty block case: closer preceded by an opener at same indent.
-    if looks_like_scope_opener(prev_line) and prev_indent <= current_indent then
+    if heuristics.is_scope_opener(prev_line, bufnr) and prev_indent <= current_indent then
       return current_indent + get_shiftwidth(bufnr)
     end
   end

--- a/tests/charwise_paste_spec.lua
+++ b/tests/charwise_paste_spec.lua
@@ -185,6 +185,111 @@ group('charwise_paste', function()
     delete_buf(bufnr)
   end)
 
+  case('p below a python opener with a trailing comment indents into the block (issue #19)', function()
+    -- Regression: an inline comment after the colon hid the opener token, so
+    -- the paste landed at column 0 instead of inside the if block.
+    local bufnr = make_buf({ 'if foo < bar: # some comment', '    baz()' })
+    vim.bo[bufnr].commentstring = '# %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('o', { 'x = 1' }, 'V')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 'o',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+      charwise_newline = false,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'if foo < bar: # some comment', '    x = 1', '    baz()' })
+    delete_buf(bufnr)
+  end)
+
+  case('p below a lua keyword opener with a trailing comment indents into the block (issue #19)', function()
+    -- Same defect for keyword openers: `then` followed by an inline `--`
+    -- comment must still read as a scope opener.
+    local bufnr = make_buf({ 'if x then -- note', 'end' })
+    vim.bo[bufnr].commentstring = '-- %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('q', { 'print(1)' }, 'V')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 'q',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+      charwise_newline = false,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'if x then -- note', '    print(1)', 'end' })
+    delete_buf(bufnr)
+  end)
+
+  case('P above a commented elif still indents into the if block (issue #19)', function()
+    -- The elif line is a keyword scope closer; a trailing comment on it must
+    -- not stop the paste from targeting the enclosing block body indent.
+    local bufnr = make_buf({ 'if foo:', 'elif baz: # note', '    blah()' })
+    vim.bo[bufnr].commentstring = '# %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('r', { '    bar()' }, 'V')
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    paste._test_set_state({
+      register = 'r',
+      count = 1,
+      key = 'P',
+      after = false,
+      follow = false,
+      charwise_newline = false,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'if foo:', '    bar()', 'elif baz: # note', '    blah()' })
+    delete_buf(bufnr)
+  end)
+
+  case('P above a closer whose opener carries a trailing comment indents into the block (issue #19)', function()
+    -- Empty-block closer branch: the opener check runs on the previous line,
+    -- so a comment there hid the `:` and the paste stayed at column 0.
+    local bufnr = make_buf({ 'if foo: # setup', 'elif baz:', '    blah()' })
+    vim.bo[bufnr].commentstring = '# %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('s', { '    bar()' }, 'V')
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    paste._test_set_state({
+      register = 's',
+      count = 1,
+      key = 'P',
+      after = false,
+      follow = false,
+      charwise_newline = false,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'if foo: # setup', '    bar()', 'elif baz:', '    blah()' })
+    delete_buf(bufnr)
+  end)
+
+  case('p on a full-line comment keeps the current indent and does not error', function()
+    -- A comment leader at the start of the line is not a trailing comment;
+    -- the heuristics must leave the line alone and paste at its own indent.
+    local bufnr = make_buf({ '# just a comment', 'x = 1' })
+    vim.bo[bufnr].commentstring = '# %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('t', { 'y = 2' }, 'V')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 't',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+      charwise_newline = false,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { '# just a comment', 'y = 2', 'x = 1' })
+    delete_buf(bufnr)
+  end)
+
   case(']p with blockwise register falls through to vanilla paste', function()
     local bufnr = make_buf({ 'alpha', 'beta' })
     vim.api.nvim_set_current_buf(bufnr)

--- a/tests/verify_task2_e2e.lua
+++ b/tests/verify_task2_e2e.lua
@@ -236,21 +236,23 @@ if top_level_count ~= 1 or scoped_count ~= 1 then
 end
 print('PASS: dot-repeat replays smart paste with new-context indentation')
 
--- Test 9: Verify all 3 modules integrate without error
+-- Test 9: Verify all 4 modules integrate without error
 local init_ok = package.loaded['smart-paste'] ~= nil
 local paste_ok = package.loaded['smart-paste.paste'] ~= nil
 local indent_ok = package.loaded['smart-paste.indent'] ~= nil
+local heuristics_ok = package.loaded['smart-paste.heuristics'] ~= nil
 assert(init_ok, 'init module not loaded')
 assert(paste_ok, 'paste module not loaded')
 assert(indent_ok, 'indent module not loaded')
-print('PASS: all 3 modules (init, paste, indent) loaded and integrated')
+assert(heuristics_ok, 'heuristics module not loaded')
+print('PASS: all 4 modules (init, paste, indent, heuristics) loaded and integrated')
 
 -- Test 10: Plugin file count check
 local handle = io.popen('ls lua/smart-paste/*.lua | wc -l')
 local file_count = tonumber(handle:read('*a'):match('%d+'))
 handle:close()
-assert(file_count == 3, 'expected 3 lua files, got ' .. file_count)
-print('PASS: plugin has exactly 3 Lua files')
+assert(file_count == 4, 'expected 4 lua files, got ' .. file_count)
+print('PASS: plugin has exactly 4 Lua files')
 
 -- Test 11: File size check (focused, minimal modules)
 local lua_files = { 'lua/smart-paste/init.lua', 'lua/smart-paste/paste.lua', 'lua/smart-paste/indent.lua' }


### PR DESCRIPTION
Refs #19, does not close it, waiting for reporter confirmation.

The scope heuristics decide opener status by what a line ends with, so an inline comment after the colon in

```
if foo < bar: # some comment
    baz()
```

hid the opener token and pastes around that line targeted the wrong indent. The same applied to keyword openers like a lua `then` followed by a `--` comment.

The opener and closer checks now strip a trailing inline comment first, using the buffer's `commentstring` to know the comment leader per filetype. The leader is only stripped when preceded by whitespace, which keeps false positives (a `#` inside a string) low.

The heuristics also moved from `paste.lua` into their own module `lua/smart-paste/heuristics.lua` since two pending fixes need them from `indent.lua` as well. `verify_task2_e2e.lua` module count checks were updated for the fourth module.

Tests: five new regression cases in `charwise_paste_spec.lua`, three of which fail on main. Full suite green.