### PR TITLE
fix: level sibling lines when rebasing a charwise block

### DIFF
--- a/lua/smart-paste/indent.lua
+++ b/lua/smart-paste/indent.lua
@@ -1,6 +1,8 @@
 --- @class SmartPaste.Indent
 local M = {}
 
+local heuristics = require('smart-paste.heuristics')
+
 --- Check whether a line is empty or whitespace-only.
 --- @param line string
 --- @return boolean blank
@@ -47,15 +49,19 @@ end
 --- Reconstruct the first line's indentation for a charwise "paste as new line".
 --- A charwise selection drops the first line's leading whitespace while inner
 --- lines keep their absolute indent, so a single uniform shift over-indents the
---- inner lines by the block's original base. When the block dedents back below
---- its first inner line (e.g. a closing tag or brace), the first line is an
---- opener whose base equals the block's minimum inner indent; re-pad it to that
---- base so the uniform shift preserves the block's relative structure. Blocks
---- that never dedent (e.g. `if x:` + body) keep the first line at column 0.
+--- inner lines by the block's original base. The lost indent forces a guess:
+--- when the block dedents back below its first inner line (e.g. a closing tag
+--- or brace), or when the first line does not look like a scope opener, the
+--- first line most likely sat at the block's minimum inner indent (siblings);
+--- re-pad it to that base so the uniform shift preserves the block's relative
+--- structure. Opener-looking (e.g. `if x:`) or blank first lines of blocks
+--- that never dedent keep the first line at column 0, inner lines nested.
 --- @param lines string[] Lines with the first line already left-stripped
+--- @param bufnr? integer Buffer whose options drive the opener heuristics (defaults to current buffer)
 --- @return string[] rebased New table; first line padded to the detected base
 --- @return integer base Visual-column base indent to use as the source indent
-function M.rebase_charwise_block(lines)
+function M.rebase_charwise_block(lines, bufnr)
+  bufnr = bufnr or 0
   local result = vim.deepcopy(lines)
   if #result == 0 then
     return result, 0
@@ -74,7 +80,8 @@ function M.rebase_charwise_block(lines)
     end
   end
 
-  if first_inner ~= nil and min_inner < first_inner then
+  local first_is_sibling = not is_blank(result[1]) and not heuristics.is_scope_opener(result[1], bufnr)
+  if first_inner ~= nil and (min_inner < first_inner or first_is_sibling) then
     result[1] = string.rep(' ', min_inner) .. result[1]
     return result, min_inner
   end

--- a/lua/smart-paste/paste.lua
+++ b/lua/smart-paste/paste.lua
@@ -213,8 +213,8 @@ function M.do_paste(_motion_type)
       -- Charwise selections drop the first line's indent but keep the inner
       -- lines' absolute indent; rebase the first line so the block's relative
       -- structure survives the shift to the target indent.
-      local rebased, source_indent = indent.rebase_charwise_block(stripped)
       local bufnr = vim.api.nvim_get_current_buf()
+      local rebased, source_indent = indent.rebase_charwise_block(stripped, bufnr)
       local row = vim.api.nvim_win_get_cursor(0)[1] - 1 -- 0-indexed
       local target_indent = resolve_linewise_target_indent(bufnr, row, after)
       local delta = target_indent - source_indent

--- a/tests/charwise_paste_spec.lua
+++ b/tests/charwise_paste_spec.lua
@@ -426,6 +426,91 @@ group('charwise_paste', function()
     delete_buf(bufnr)
   end)
 
+  case(']p levels sibling lines when the first charwise line is not an opener (issue #17)', function()
+    -- A mid-line charwise yank of two sibling statements drops line 1's
+    -- indent; the old rebase always nested the inner lines under line 1,
+    -- over-indenting baz() by the block's original base.
+    local bufnr = make_buf({ 'x = 1', '' })
+    vim.bo[bufnr].commentstring = '# %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('j', { 'bar()', '    baz()' }, 'v')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 'j',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'x = 1', 'bar()', 'baz()', '' })
+    delete_buf(bufnr)
+  end)
+
+  case(']p keeps charwise siblings level at an indented target (issue #17)', function()
+    -- Same sibling block pasted inside a function body: both lines must land
+    -- at the body indent, not one level apart.
+    local bufnr = make_buf({ 'def f():', '    x = 1', '' })
+    vim.bo[bufnr].commentstring = '# %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('u', { 'bar()', '    baz()' }, 'v')
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    paste._test_set_state({
+      register = 'u',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'def f():', '    x = 1', '    bar()', '    baz()', '' })
+    delete_buf(bufnr)
+  end)
+
+  case(']p keeps a blank first charwise line blank instead of padding it', function()
+    -- A charwise yank starting on an empty line carries no sibling evidence;
+    -- the first line must stay blank, not become a whitespace-only line with
+    -- the inner lines flattened to it.
+    local bufnr = make_buf({ 'x = 1', '' })
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('w', { '', '    baz()', '' }, 'v')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 'w',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'x = 1', '', '    baz()', '' })
+    delete_buf(bufnr)
+  end)
+
+  case(']p still nests inner lines under a brace opener first line', function()
+    -- An opener-looking first line keeps the nesting guess: the body stays one
+    -- level inside the block after the rebase.
+    local bufnr = make_buf({ 'x = 1', '' })
+    vim.bo[bufnr].commentstring = '// %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('v', { 'function foo() {', '    body()' }, 'v')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 'v',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'x = 1', 'function foo() {', '    body()', '' })
+    delete_buf(bufnr)
+  end)
+
   case(']p with empty charwise register does not crash', function()
     local bufnr = make_buf({ 'def foo():', '    x = 1', '' })
     vim.api.nvim_set_current_buf(bufnr)


### PR DESCRIPTION
Refs #17, does not close it, waiting for reporter confirmation. Builds on the trailing comment fix branch, merge that one first.

A charwise yank that starts mid line drops the first line's leading whitespace, so the paste conversion has to guess the block's structure. The old guess always nested the inner lines under line 1, which over indented siblings:

```
yank 'bar()' + '    baz()' charwise, ]p gave
bar()
    baz()
```

`rebase_charwise_block` now checks whether the first line looks like a scope opener. Opener looking first lines (`if x:`, `foo() {`, tag openers) keep the nesting guess. Non opener first lines are rebased to the minimum inner indent so siblings land level. Blank first lines keep the old behavior since they carry no evidence either way.

Known tradeoff, stated in the doc comment: continuation constructs whose first line does not end in an opener token (aligned call arguments, method chains) are now leveled too. The structure is genuinely ambiguous once the first line's indent is gone.

Tests: four new regression cases including the reported sibling scenario and a blank first line guard. Full suite green.