### PR TITLE
feat: add multiline mode for charwise_newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ require('smart-paste').setup({
 })
 ```
 
+`charwise_newline` controls what happens when the register holds charwise content: `true` always converts the paste to an indented new line (like `]p`), `false` never does, and `'multiline'` converts only when the yank spans multiple lines, so a single yanked word still pastes inline:
+
+```lua
+require('smart-paste').setup({
+  keys = {
+    { lhs = 'p', like = 'p', charwise_newline = 'multiline' },
+    { lhs = 'P', like = 'P', charwise_newline = 'multiline' },
+  },
+})
+```
+
 Shorthand remap by inheriting behavior from a built-in key:
 
 ```lua

--- a/doc/smart-paste.txt
+++ b/doc/smart-paste.txt
@@ -120,11 +120,26 @@ Example custom bindings:
   Keys to remap in normal mode. Accepts flat strings and structured entries.
   String values: `p`, `P`, `gp`, `gP`, `]p`, `[p`.
   Structured form:
-    { lhs = 'key', after = bool, follow = bool, charwise_newline = bool }
+    { lhs = 'key', after = bool, follow = bool, charwise_newline = value }
   Alias form:
     { lhs = 'key', like = ']p' }
   where `like` may be one of: `p`, `P`, `gp`, `gP`, `]p`, `[p`.
   Mixed formats are supported. Visual mode uses only `p` and `P`.
+
+  `charwise_newline` values:
+  - `true`        always convert charwise pastes to an indented new line
+                  (like `]p`)
+  - `false`       never convert; charwise pastes stay inline
+  - `'multiline'` convert only when the yank spans multiple lines, so a
+                  single yanked word still pastes inline:
+>
+    require('smart-paste').setup({
+      keys = {
+        { lhs = 'p', like = 'p', charwise_newline = 'multiline' },
+        { lhs = 'P', like = 'P', charwise_newline = 'multiline' },
+      },
+    })
+<
 
 `exclude_filetypes` (string[])
   Filetypes where smart paste is bypassed and vanilla paste is used.

--- a/lua/smart-paste/init.lua
+++ b/lua/smart-paste/init.lua
@@ -4,7 +4,7 @@ local M = {}
 --- @class SmartPasteKeyFlags
 --- @field after boolean
 --- @field follow boolean
---- @field charwise_newline boolean
+--- @field charwise_newline boolean|'multiline'
 
 --- @class SmartPasteKeyEntry : SmartPasteKeyFlags
 --- @field lhs string
@@ -14,7 +14,7 @@ local M = {}
 --- @field like? string
 --- @field after? boolean
 --- @field follow? boolean
---- @field charwise_newline? boolean
+--- @field charwise_newline? boolean|'multiline'
 
 --- @class SmartPasteConfig
 --- @field keys SmartPasteKeyEntry[]
@@ -86,6 +86,8 @@ end
 
 --- Normalize a key config entry to a canonical table shape.
 --- Accepts legacy string entries and structured table entries.
+--- `charwise_newline` accepts `true`, `false`, or `'multiline'`; any other
+--- value falls back to the `like` preset (or `false`).
 --- Invalid entries are skipped by returning nil.
 --- @param entry string|SmartPasteKeyInput
 --- @return SmartPasteKeyEntry|nil normalized_key_entry
@@ -129,6 +131,9 @@ local function normalize_key_entry(entry)
     end
 
     local charwise_newline = entry.charwise_newline
+    if charwise_newline ~= true and charwise_newline ~= false and charwise_newline ~= 'multiline' then
+      charwise_newline = nil
+    end
     if charwise_newline == nil and like_flags then
       charwise_newline = like_flags.charwise_newline
     end

--- a/lua/smart-paste/paste.lua
+++ b/lua/smart-paste/paste.lua
@@ -167,9 +167,10 @@ end
 --- Reads the register (never mutates it), computes indent delta for
 --- linewise content, and places text via a single `nvim_put` call
 --- for undo atomicity. When `charwise_newline` is enabled for a key entry,
---- charwise register content is converted to indented linewise paste.
---- Other charwise/blockwise operations fall through to vanilla paste via
---- `nvim_feedkeys`.
+--- charwise register content is converted to indented linewise paste;
+--- the `'multiline'` value applies the conversion only when the register
+--- effectively spans more than one line. Other charwise/blockwise
+--- operations fall through to vanilla paste via `nvim_feedkeys`.
 ---
 --- @param _motion_type string Ignored; required by operatorfunc signature
 function M.do_paste(_motion_type)
@@ -204,11 +205,21 @@ function M.do_paste(_motion_type)
   local is_linewise = vim.startswith(reginfo.regtype, 'V')
 
   if not is_linewise then
-    local charwise_newline = state.charwise_newline == true
+    local newline_mode = state.charwise_newline
     local is_charwise = (reginfo.regtype == 'v')
 
-    if charwise_newline and is_charwise then
-      local lines = strip_trailing_blank_lines(reginfo.regcontents)
+    local lines
+    if is_charwise and (newline_mode == true or newline_mode == 'multiline') then
+      lines = strip_trailing_blank_lines(reginfo.regcontents)
+      -- 'multiline' converts only when the yank effectively spans more than
+      -- one line. The count is taken after dropping the `v$` trailing blank,
+      -- so a single yanked word (or line) keeps the vanilla inline paste.
+      if newline_mode == 'multiline' and #lines <= 1 then
+        lines = nil
+      end
+    end
+
+    if lines then
       local stripped = strip_leading_whitespace(lines)
       -- Charwise selections drop the first line's indent but keep the inner
       -- lines' absolute indent; rebase the first line so the block's relative

--- a/tests/charwise_paste_spec.lua
+++ b/tests/charwise_paste_spec.lua
@@ -511,6 +511,108 @@ group('charwise_paste', function()
     delete_buf(bufnr)
   end)
 
+  case("p with charwise_newline = 'multiline' converts a multiline charwise yank to linewise", function()
+    -- Issue #18: the 'multiline' mode makes p behave like ]p only when the
+    -- charwise yank spans multiple lines.
+    local bufnr = make_buf({ 'x = 1', '' })
+    vim.bo[bufnr].commentstring = '# %s'
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('w', { 'bar()', '    baz()' }, 'v')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 'w',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+      charwise_newline = 'multiline',
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'x = 1', 'bar()', 'baz()', '' })
+    delete_buf(bufnr)
+  end)
+
+  case("p with charwise_newline = 'multiline' pastes a single-line yank inline", function()
+    -- A single yanked word must keep the vanilla inline paste instead of
+    -- being forced onto its own line.
+    local bufnr = make_buf({ 'x = 1', '' })
+    vim.api.nvim_set_current_buf(bufnr)
+    local orig_feedkeys = vim.api.nvim_feedkeys
+    local calls = 0
+    vim.api.nvim_feedkeys = function(...)
+      calls = calls + 1
+      return nil
+    end
+
+    vim.fn.setreg('x', 'word', 'v')
+    paste._test_set_state({
+      register = 'x',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+      charwise_newline = 'multiline',
+    })
+    paste.do_paste('line')
+
+    vim.api.nvim_feedkeys = orig_feedkeys
+    if calls ~= 1 then
+      delete_buf(bufnr)
+      error('expected one vanilla fallback call for a single-line charwise register')
+    end
+    delete_buf(bufnr)
+  end)
+
+  case("p with charwise_newline = 'multiline' treats a v$ trailing blank as single-line", function()
+    -- A `v$` yank of one line captures the trailing newline as an empty
+    -- entry; the effective line count is taken after dropping it, so the
+    -- paste still falls through inline.
+    local bufnr = make_buf({ 'x = 1', '' })
+    vim.api.nvim_set_current_buf(bufnr)
+    local orig_feedkeys = vim.api.nvim_feedkeys
+    local calls = 0
+    vim.api.nvim_feedkeys = function(...)
+      calls = calls + 1
+      return nil
+    end
+
+    vim.fn.setreg('y', { 'word', '' }, 'v')
+    paste._test_set_state({
+      register = 'y',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+      charwise_newline = 'multiline',
+    })
+    paste.do_paste('line')
+
+    vim.api.nvim_feedkeys = orig_feedkeys
+    if calls ~= 1 then
+      delete_buf(bufnr)
+      error('expected one vanilla fallback call for a v$ single-line charwise register')
+    end
+    delete_buf(bufnr)
+  end)
+
+  case("p with charwise_newline = 'multiline' keeps the smart linewise path for linewise registers", function()
+    local bufnr = make_buf({ 'def foo():', '    x = 1', '' })
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('z', { 'item' }, 'V')
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    paste._test_set_state({
+      register = 'z',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+      charwise_newline = 'multiline',
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'def foo():', '    x = 1', '    item', '' })
+    delete_buf(bufnr)
+  end)
+
   case(']p with empty charwise register does not crash', function()
     local bufnr = make_buf({ 'def foo():', '    x = 1', '' })
     vim.api.nvim_set_current_buf(bufnr)


### PR DESCRIPTION
Refs #18, does not close it, waiting for reporter feedback on the semantics. Builds on the charwise sibling fix branch, merge the stack in order.

`charwise_newline` now accepts `'multiline'` in addition to `true` and `false`. With

```lua
keys = { { lhs = 'p', like = 'p', charwise_newline = 'multiline' }, ... }
```

a charwise register spanning several lines is pasted as indented lines like `]p`, while a single yanked word still pastes inline at the cursor. A `v$` yank of one line, whose register carries a trailing empty entry, counts as single line and stays inline. Defaults are unchanged, the value is opt in.

README and vimdoc document the three values.

Tests: four new cases covering conversion, inline fall through, the `v$` artifact and linewise registers. Full suite green.