### PR TITLE
fix: preserve registers in visual paste fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Smart paste applies to linewise registers (for example: `yy`, `dd`, `2yy`, or li
 For charwise registers, `]p` and `[p` convert inline content into smart-indented new lines.
 Characterwise paste on `p`/`P`/`gp`/`gP` and blockwise (`<C-v>`) paste use native Neovim behavior.
 Visual `V` + `p`/`P` also falls back to native behavior when the source register is charwise or blockwise.
+Visual fallbacks are fed as native `P`, so the text you paste over never overwrites the register. This matches the smart path, where registers are read but never rewritten.
 
 Example escape-hatch bindings:
 

--- a/doc/smart-paste.txt
+++ b/doc/smart-paste.txt
@@ -99,7 +99,9 @@ Default normal-mode mappings:
 Default visual-mode mappings:
 - `p`   replace linewise visual selection with smart-indented linewise content
 - `P`   same replacement behavior (linewise visual mode)
-       (charwise/blockwise source registers fall through to native paste)
+       (charwise/blockwise selections and source registers fall through to
+        native paste, fed as `P` so the replaced text never overwrites
+        registers)
 
 Escape hatches (vanilla behavior):
 - `<Plug>(smart-paste-raw-p)`
@@ -174,6 +176,7 @@ For charwise `]p`/`[p` conversion:
 Visual linewise replacement:
 1. Read register
 2. If register is not linewise, fall through to native visual paste
+   (fed as `P`, which does not overwrite registers)
 3. Delete selected lines with `nvim_buf_set_lines()`
 4. Insert adjusted lines with `nvim_put()`
 
@@ -189,7 +192,9 @@ How do `]p` and `[p` differ from regular `p`/`P`?
   behavior for charwise registers.
 
 Does this plugin modify registers?
-  No. Register content is read and transformed in memory only.
+  No. Register content is read and transformed in memory only. This includes
+  visual paste, where the text you paste over is never written back into a
+  register (native visual `p` would put it in the unnamed register).
 
 Why does visual mode smart paste focus on linewise (`V`) selection?
   It preserves predictable indentation semantics and avoids block/column

--- a/lua/smart-paste/paste.lua
+++ b/lua/smart-paste/paste.lua
@@ -257,29 +257,36 @@ function M.do_paste(_motion_type)
   vim.api.nvim_put(final_lines, 'l', after, follow)
 end
 
+--- Feed a native paste over the last visual selection.
+--- Always feeds `P` no matter which key was pressed. In visual mode `p` and
+--- `P` place text identically, but `P` leaves registers untouched, so the
+--- replaced selection never overwrites the register being pasted from.
+--- @param reg string Register name
+local function feed_native_visual_paste(reg)
+  local raw_keys = 'gv"' .. reg .. 'P'
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(raw_keys, true, false, true), 'n', false)
+end
+
 --- Perform smart visual-mode paste for a previously selected region.
 --- Supports smart indentation only for linewise visual mode (`V`), and falls
---- back to vanilla visual paste for charwise/blockwise selections.
+--- back to native visual paste for charwise/blockwise selections. Both the
+--- smart path and the fallback preserve register contents.
 ---
 --- The caller is expected to exit visual mode before invoking this function so
 --- that `'<` and `'>` marks represent the latest visual selection.
 ---
 --- @param reg string Register name
---- @param key string Paste key (`p` or `P`)
+--- @param _key string Pressed paste key. Unused, `p` and `P` behave the same in visual mode.
 --- @param vmode string Visual mode kind (`v`, `V`, or blockwise)
 --- @param count_override? number Optional count override (test helper)
-function M.do_visual_paste(reg, key, vmode, count_override)
+function M.do_visual_paste(reg, _key, vmode, count_override)
   if not reg or reg == '' then
     reg = '"'
-  end
-  if not key or key == '' then
-    key = 'p'
   end
 
   -- Gate: only linewise visual selections get smart indentation.
   if vmode ~= 'V' then
-    local raw_keys = 'gv"' .. reg .. key
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(raw_keys, true, false, true), 'n', false)
+    feed_native_visual_paste(reg)
     return
   end
 
@@ -293,8 +300,7 @@ function M.do_visual_paste(reg, key, vmode, count_override)
   -- Charwise/blockwise registers fall through to native visual paste.
   local is_linewise_register = type(reginfo.regtype) == 'string' and vim.startswith(reginfo.regtype, 'V')
   if not is_linewise_register then
-    local raw_keys = 'gv"' .. reg .. key
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(raw_keys, true, false, true), 'n', false)
+    feed_native_visual_paste(reg)
     return
   end
 

--- a/tests/visual_paste_spec.lua
+++ b/tests/visual_paste_spec.lua
@@ -129,20 +129,22 @@ group('visual_paste', function()
     vim.api.nvim_set_current_buf(bufnr)
 
     local orig_feedkeys = vim.api.nvim_feedkeys
-    local calls = 0
-    vim.api.nvim_feedkeys = function(...)
-      calls = calls + 1
-      return orig_feedkeys(...)
+    local fed_keys = nil
+    -- Pure mock. Do not forward to the real feedkeys, otherwise the paste
+    -- keys stay queued in typeahead and leak into later tests.
+    vim.api.nvim_feedkeys = function(keys)
+      fed_keys = keys
     end
 
     vim.fn.setreg('c', 'XX', 'v')
     paste.do_visual_paste('c', 'p', 'v')
 
     vim.api.nvim_feedkeys = orig_feedkeys
-    if calls == 0 then
+    if not fed_keys then
       delete_buf(bufnr)
       error('expected vanilla fallback to call nvim_feedkeys')
     end
+    assert_eq(fed_keys, 'gv"cP', 'fallback should paste with register-preserving P')
     delete_buf(bufnr)
   end)
 
@@ -152,20 +154,22 @@ group('visual_paste', function()
     set_selection(bufnr, 1, 2)
 
     local orig_feedkeys = vim.api.nvim_feedkeys
-    local calls = 0
-    vim.api.nvim_feedkeys = function(...)
-      calls = calls + 1
-      return orig_feedkeys(...)
+    local fed_keys = nil
+    -- Pure mock. Do not forward to the real feedkeys, otherwise the paste
+    -- keys stay queued in typeahead and leak into later tests.
+    vim.api.nvim_feedkeys = function(keys)
+      fed_keys = keys
     end
 
     vim.fn.setreg('z', 'XX', 'v')
     paste.do_visual_paste('z', 'p', 'V')
 
     vim.api.nvim_feedkeys = orig_feedkeys
-    if calls == 0 then
+    if not fed_keys then
       delete_buf(bufnr)
       error('expected charwise register in linewise visual mode to call nvim_feedkeys')
     end
+    assert_eq(fed_keys, 'gv"zP', 'fallback should paste with register-preserving P')
     delete_buf(bufnr)
   end)
 
@@ -174,20 +178,43 @@ group('visual_paste', function()
     vim.api.nvim_set_current_buf(bufnr)
 
     local orig_feedkeys = vim.api.nvim_feedkeys
-    local calls = 0
-    vim.api.nvim_feedkeys = function(...)
-      calls = calls + 1
-      return orig_feedkeys(...)
+    local fed_keys = nil
+    -- Pure mock. Do not forward to the real feedkeys, otherwise the paste
+    -- keys stay queued in typeahead and leak into later tests.
+    vim.api.nvim_feedkeys = function(keys)
+      fed_keys = keys
     end
 
     vim.fn.setreg('d', { 'YY' }, '\0222')
     paste.do_visual_paste('d', 'p', '\022')
 
     vim.api.nvim_feedkeys = orig_feedkeys
-    if calls == 0 then
+    if not fed_keys then
       delete_buf(bufnr)
       error('expected blockwise fallback to call nvim_feedkeys')
     end
+    assert_eq(fed_keys, 'gv"dP', 'fallback should paste with register-preserving P')
+    delete_buf(bufnr)
+  end)
+
+  case('charwise fallback paste preserves register contents', function()
+    local bufnr = make_buf({ 'alpha', 'beta' })
+    vim.api.nvim_set_current_buf(bufnr)
+
+    vim.fn.setreg('c', 'XX', 'v')
+    -- Make a real charwise selection over "alpha" so gv can restore it.
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    vim.cmd.normal({ args = { 've\27' }, bang = true })
+    local before = snapshot_registers()
+
+    paste.do_visual_paste('c', 'p', 'v')
+    -- The fallback queues keys through nvim_feedkeys. Flush them so the
+    -- paste actually runs before we compare registers.
+    vim.api.nvim_feedkeys('', 'x', false)
+
+    assert_eq(get_lines(bufnr), { 'XX', 'beta' })
+    local after = snapshot_registers()
+    assert_eq(after, before, 'fallback paste should not rewrite registers')
     delete_buf(bufnr)
   end)
 


### PR DESCRIPTION
Native visual p writes the replaced selection into the unnamed register. The smart linewise path already avoided this, but the charwise and blockwise fallbacks fed the pressed key through to native paste. The fallback now pastes with P, which places text the same way and leaves registers untouched.

Closes #25