### PR TITLE
fix: strip CRLF from system clipboard registers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
             -c "PlenaryBustedFile tests/indent_spec.lua { minimal_init = 'tests/minimal_init.lua', sequential = true, timeout = 60000 }" \
             -c "PlenaryBustedFile tests/visual_paste_spec.lua { minimal_init = 'tests/minimal_init.lua', sequential = true, timeout = 60000 }" \
             -c "PlenaryBustedFile tests/charwise_paste_spec.lua { minimal_init = 'tests/minimal_init.lua', sequential = true, timeout = 60000 }" \
+            -c "PlenaryBustedFile tests/clipboard_crlf_spec.lua { minimal_init = 'tests/minimal_init.lua', sequential = true, timeout = 60000 }" \
             -c "qa!"
       - name: Run integration verification
         run: |

--- a/lua/smart-paste/paste.lua
+++ b/lua/smart-paste/paste.lua
@@ -32,6 +32,27 @@ local function strip_leading_whitespace(lines)
   return result
 end
 
+--- Strip the trailing carriage return from each line when reading a system
+--- clipboard register (`+` or `*`). Windows clipboard providers (win32yank
+--- on WSL, for example) can hand over CRLF line endings. The stray `\r`
+--- ends up verbatim in the buffer and also breaks the indent heuristics,
+--- since a line like `if x then\r` no longer matches the opener patterns.
+--- Other registers are left untouched, so yanked buffer content that
+--- genuinely contains `^M` characters still pastes like vanilla.
+--- @param reg string Register name
+--- @param lines string[]
+--- @return string[]
+local function strip_clipboard_cr(reg, lines)
+  if reg ~= '+' and reg ~= '*' then
+    return lines
+  end
+  local result = {}
+  for i, line in ipairs(lines) do
+    result[i] = line:gsub('\r$', '')
+  end
+  return result
+end
+
 --- Remove trailing empty lines from a list (always keeps at least one line).
 --- A charwise selection ending at a line boundary (e.g. `v$`) captures the
 --- trailing newline as an empty entry; dropping it avoids a stray blank line
@@ -202,6 +223,7 @@ function M.do_paste(_motion_type)
     return
   end
 
+  local contents = strip_clipboard_cr(reg, reginfo.regcontents)
   local is_linewise = vim.startswith(reginfo.regtype, 'V')
 
   if not is_linewise then
@@ -210,7 +232,7 @@ function M.do_paste(_motion_type)
 
     local lines
     if is_charwise and (newline_mode == true or newline_mode == 'multiline') then
-      lines = strip_trailing_blank_lines(reginfo.regcontents)
+      lines = strip_trailing_blank_lines(contents)
       -- 'multiline' converts only when the yank effectively spans more than
       -- one line. The count is taken after dropping the `v$` trailing blank,
       -- so a single yanked word (or line) keeps the vanilla inline paste.
@@ -240,7 +262,7 @@ function M.do_paste(_motion_type)
     return
   end
 
-  local lines = reginfo.regcontents
+  local lines = contents
 
   -- Compute indent delta using the indent engine
   local source_indent = indent.get_source_indent(lines)
@@ -315,7 +337,7 @@ function M.do_visual_paste(reg, _key, vmode, count_override)
 
   local count = count_override or vim.v.count1
   local bufnr = vim.api.nvim_get_current_buf()
-  local source_lines = reginfo.regcontents
+  local source_lines = strip_clipboard_cr(reg, reginfo.regcontents)
   local target_indent = select(1, resolve_row_context_indent(bufnr, start_row - 1))
   local source_indent = indent.get_source_indent(source_lines)
   local delta = target_indent - source_indent

--- a/tests/clipboard_crlf_spec.lua
+++ b/tests/clipboard_crlf_spec.lua
@@ -1,0 +1,182 @@
+local paste = require('smart-paste.paste')
+
+local has_busted = type(describe) == 'function' and type(it) == 'function'
+
+local function group(_name, fn)
+  if has_busted then
+    describe(_name, fn)
+  else
+    fn()
+  end
+end
+
+local function case(_name, fn)
+  if has_busted then
+    it(_name, fn)
+    return
+  end
+
+  local ok, err = pcall(fn)
+  if not ok then
+    error(_name .. ': ' .. tostring(err))
+  end
+end
+
+local function make_buf(lines)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.bo[bufnr].expandtab = true
+  vim.bo[bufnr].tabstop = 4
+  vim.bo[bufnr].shiftwidth = 4
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  return bufnr
+end
+
+local function delete_buf(bufnr)
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end
+end
+
+local function set_selection(bufnr, start_row, end_row)
+  vim.api.nvim_buf_set_mark(bufnr, '<', start_row, 0, {})
+  vim.api.nvim_buf_set_mark(bufnr, '>', end_row, 0, {})
+end
+
+local function get_lines(bufnr)
+  return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+end
+
+local function assert_eq(actual, expected, msg)
+  if not vim.deep_equal(actual, expected) then
+    local actual_text = vim.inspect(actual)
+    local expected_text = vim.inspect(expected)
+    error((msg or 'assertion failed') .. '\nexpected: ' .. expected_text .. '\nactual: ' .. actual_text)
+  end
+end
+
+-- Fake clipboard provider so tests run headless without a real system
+-- clipboard. The paste callback returns whatever `clipboard_store` holds,
+-- which lets each case hand the `+` register lines with CRLF endings,
+-- exactly what win32yank produces on WSL.
+local clipboard_store = { {}, 'v' }
+
+local function install_fake_clipboard()
+  vim.g.clipboard = {
+    name = 'fake-crlf-test',
+    copy = {
+      ['+'] = function(lines, regtype)
+        clipboard_store = { lines, regtype }
+      end,
+      ['*'] = function(lines, regtype)
+        clipboard_store = { lines, regtype }
+      end,
+    },
+    paste = {
+      ['+'] = function()
+        return clipboard_store
+      end,
+      ['*'] = function()
+        return clipboard_store
+      end,
+    },
+  }
+  -- Force the provider to re-read g:clipboard in case another spec
+  -- already triggered clipboard detection.
+  vim.g.loaded_clipboard_provider = nil
+  vim.cmd('runtime autoload/provider/clipboard.vim')
+end
+
+group('clipboard_crlf', function()
+  install_fake_clipboard()
+
+  case(']p strips trailing \\r from linewise clipboard content', function()
+    local bufnr = make_buf({ 'local function test()', '    print("antes")', 'end' })
+    vim.api.nvim_set_current_buf(bufnr)
+    clipboard_store = {
+      { 'if condition then\r', '    print("a")\r', 'end\r' },
+      'V',
+    }
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = '+',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), {
+      'local function test()',
+      'if condition then',
+      '    print("a")',
+      'end',
+      '    print("antes")',
+      'end',
+    })
+    delete_buf(bufnr)
+  end)
+
+  case(']p strips trailing \\r from the * register too', function()
+    local bufnr = make_buf({ 'def foo():', '    x = 1' })
+    vim.api.nvim_set_current_buf(bufnr)
+    clipboard_store = { { 'return x\r' }, 'V' }
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    paste._test_set_state({
+      register = '*',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'def foo():', '    x = 1', '    return x' })
+    delete_buf(bufnr)
+  end)
+
+  case(']p strips trailing \\r from multi-line charwise clipboard content', function()
+    local bufnr = make_buf({ 'if true then', '    x = 1', 'end' })
+    vim.api.nvim_set_current_buf(bufnr)
+    clipboard_store = { { 'y = 2\r', 'z = 3\r' }, 'v' }
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    paste._test_set_state({
+      register = '+',
+      count = 1,
+      key = ']p',
+      after = true,
+      follow = false,
+      charwise_newline = true,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'if true then', '    x = 1', '    y = 2', '    z = 3', 'end' })
+    delete_buf(bufnr)
+  end)
+
+  case('visual paste strips trailing \\r from linewise clipboard content', function()
+    local bufnr = make_buf({ 'if true then', '    old = 1', 'end' })
+    vim.api.nvim_set_current_buf(bufnr)
+    clipboard_store = { { 'new = 2\r' }, 'V' }
+    set_selection(bufnr, 2, 2)
+    paste.do_visual_paste('+', 'p', 'V', 1)
+    assert_eq(get_lines(bufnr), { 'if true then', '    new = 2', 'end' })
+    delete_buf(bufnr)
+  end)
+
+  case('named registers keep literal \\r characters like vanilla paste', function()
+    local bufnr = make_buf({ 'top', 'bottom' })
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.fn.setreg('a', { 'keeps cr\r' }, 'V')
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    paste._test_set_state({
+      register = 'a',
+      count = 1,
+      key = 'p',
+      after = true,
+      follow = false,
+    })
+    paste.do_paste('line')
+    assert_eq(get_lines(bufnr), { 'top', 'keeps cr\r', 'bottom' })
+    delete_buf(bufnr)
+  end)
+end)


### PR DESCRIPTION
Clipboard providers on Windows hand over lines that end in a carriage return, and the stray characters both landed verbatim in the buffer and defeated the opener detection in the indent heuristics. Content read from the + and * registers now loses the trailing carriage return, in normal and visual paste. Other registers stay untouched, so yanked buffer content that really contains ^M characters still pastes like vanilla.

Closes #27